### PR TITLE
Add display name property to settings_layer

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -82,6 +82,7 @@
         };
 
         settings_layer {
+            display-name = "Settings";
             bindings = <
 &trans      &trans        &trans        &trans        &trans        &trans          &trans  &trans  &trans  &trans  &trans  &trans
 &bt BT_CLR  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4    &trans  &trans  &trans  &trans  &trans  &trans

--- a/keymap-drawer/corne.svg
+++ b/keymap-drawer/corne.svg
@@ -642,8 +642,8 @@ path.combo {
 </g>
 </g>
 </g>
-<g transform="translate(30, 992)" class="layer-settings">
-<text x="0" y="28" class="label">settings:</text>
+<g transform="translate(30, 992)" class="layer-Settings">
+<text x="0" y="28" class="label">Settings:</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 49)" class="key trans keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>

--- a/keymap-drawer/corne.yaml
+++ b/keymap-drawer/corne.yaml
@@ -88,7 +88,7 @@ layers:
   - RET
   - {type: held}
   - RALT
-  settings:
+  Settings:
   - {t: ▽, type: trans}
   - {t: ▽, type: trans}
   - {t: ▽, type: trans}


### PR DESCRIPTION
In ZMK layers have an optional property called display-name that controls what shows on the current layer widget on the oled see https://zmk.dev/docs/config/keymap#devicetree